### PR TITLE
List photos

### DIFF
--- a/app/controllers/albums.js
+++ b/app/controllers/albums.js
@@ -68,3 +68,27 @@ exports.boughts = (request, response) => {
       response.status(400).send(errors.listAlbumError('Unexpected error'));
     });
 };
+
+exports.photo = (request, response) => {
+  if (!request.userLogged)
+    return response.status(400).send(errors.authenticationError(['You must be logged to see the photos']));
+  const handleError = (err, message) => {
+    logger.error(err);
+    response.status(400).send(errors.buyAlbumError(message));
+  };
+  Album.findByAlbumAndUser(request.params.id, request.userLogged.id)
+    .then(purchasedAlbum => {
+      if (purchasedAlbum) {
+        albumService
+          .getPhotos()
+          .then(photos => {
+            const photosFiltered = photos.filter(photo => purchasedAlbum.id === photo.albumId);
+            response.status(200).send(photosFiltered);
+          })
+          .catch(error => handleError(error, errors.listPhotosError(`Can't fetch the album URL`)));
+      } else response.status(200).send(`The user has not purchased this album`);
+    })
+    .catch(error =>
+      handleError(error, errors.listPhotosError(`Unexpected error when listing the purchased albums`))
+    );
+};

--- a/app/controllers/albums.js
+++ b/app/controllers/albums.js
@@ -56,8 +56,6 @@ exports.boughts = (request, response) => {
 };
 
 exports.photo = (request, response) => {
-  if (!request.userLogged)
-    return response.status(400).send(errors.authenticationError(['You must be logged to see the photos']));
   const handleError = (err, message) => {
     logger.error(err);
     response.status(400).send(errors.buyAlbumError(message));
@@ -66,11 +64,8 @@ exports.photo = (request, response) => {
     .then(purchasedAlbum => {
       if (purchasedAlbum) {
         albumService
-          .getPhotos()
-          .then(photos => {
-            const photosFiltered = photos.filter(photo => purchasedAlbum.id === photo.albumId);
-            response.status(200).send(photosFiltered);
-          })
+          .getPhotos(purchasedAlbum.id)
+          .then(photos => response.status(200).send(photos))
           .catch(error => handleError(error, errors.listPhotosError(`Can't fetch the album URL`)));
       } else response.status(200).send(`The user has not purchased this album`);
     })

--- a/app/errors.js
+++ b/app/errors.js
@@ -22,3 +22,6 @@ exports.buyAlbumError = messages => internalError(messages, exports.BUY_ALBUM_ER
 
 exports.LIST_ALBUM_ERROR = 'list_album_error';
 exports.listAlbumError = messages => internalError(messages, exports.LIST_ALBUM_ERROR);
+
+exports.LIST_PHOTOS_ERROR = 'list_photos_error';
+exports.listPhotosError = messages => internalError(messages, exports.LIST_PHOTOS_ERROR);

--- a/app/routes.js
+++ b/app/routes.js
@@ -12,4 +12,5 @@ exports.init = app => {
   app.get('/albums', [authMw.authenticated], albums.getAll);
   app.post('/albums/:id', [authMw.authenticated], albums.buy);
   app.get('/users/:user_id/albums', [authMw.authenticated], albums.boughts);
+  app.get('/users/albums/:id/photos', [authMw.authenticated], albums.photo);
 };

--- a/app/routes.js
+++ b/app/routes.js
@@ -17,5 +17,5 @@ exports.init = app => {
     [authMw.authenticated, authMw.logRequired, albumMw.checkRequestedId],
     albums.boughts
   );
-  app.get('/users/albums/:id/photos', [authMw.authenticated], albums.photo);
+  app.get('/users/albums/:id/photos', [authMw.authenticated, authMw.logRequired], albums.photo);
 };

--- a/app/services/albums.js
+++ b/app/services/albums.js
@@ -11,3 +11,5 @@ exports.getAll = response =>
       logger.error(error);
       response.status(404).send(errors.albumApiError(['Can not resolve the albums URL']));
     });
+
+exports.getPhotos = () => fetch(`${URL}/photos`).then(res => res.json());

--- a/test/albums.js
+++ b/test/albums.js
@@ -29,6 +29,44 @@ const resMocked = [
   }
 ];
 
+const photosMocked = [
+  {
+    albumId: 1,
+    id: 1,
+    title: 'accusamus beatae ad facilis cum similique qui sunt',
+    url: 'https://via.placeholder.com/600/92c952',
+    thumbnailUrl: 'https://via.placeholder.com/150/92c952'
+  },
+  {
+    albumId: 1,
+    id: 2,
+    title: 'reprehenderit est deserunt velit ipsam',
+    url: 'https://via.placeholder.com/600/771796',
+    thumbnailUrl: 'https://via.placeholder.com/150/771796'
+  },
+  {
+    albumId: 1,
+    id: 3,
+    title: 'officia porro iure quia iusto qui ipsa ut modi',
+    url: 'https://via.placeholder.com/600/24f355',
+    thumbnailUrl: 'https://via.placeholder.com/150/24f355'
+  },
+  {
+    albumId: 2,
+    id: 4,
+    title: 'culpa odio esse rerum omnis laboriosam voluptate repudiandae',
+    url: 'https://via.placeholder.com/600/d32776',
+    thumbnailUrl: 'https://via.placeholder.com/150/d32776'
+  },
+  {
+    albumId: 3,
+    id: 5,
+    title: 'natus nisi omnis corporis facere molestiae rerum in',
+    url: 'https://via.placeholder.com/600/f66b97',
+    thumbnailUrl: 'https://via.placeholder.com/150/f66b97'
+  }
+];
+
 const handleError = (error, expectedMessage, expectedInternalCode) => {
   error.should.have.status(400);
   const { message, internalCode } = error.response.body;
@@ -164,6 +202,40 @@ describe('users', () => {
         .then(res => {
           res.should.have.status(200);
           res.body[0].should.deep.equal(resMocked[0]);
+          dictum.chai(res);
+        })
+        .then(() => done());
+    });
+  });
+  describe('/users/:user_id/albums GET', () => {
+    const test = id => fetch(regular, 'get', `/users/albums/${id}/photos`);
+    it('should fail because user not logged', done => {
+      chai
+        .request(server)
+        .get(`/users/albums/1/photos`)
+        .catch(error =>
+          handleError(error, 'You must be logged to see the photos', errors.AUTHENTICATION_ERROR)
+        )
+        .then(() => done());
+    });
+    it('should success and return a message telling that the user does not purchased the album', done => {
+      test(2)
+        .then(res => {
+          res.should.have.status(200);
+          res.text.should.equal('The user has not purchased this album');
+          dictum.chai(res);
+        })
+        .then(() => done());
+    });
+    it('should success when listing photos of a purchased album', done => {
+      nock('https://jsonplaceholder.typicode.com')
+        .get('/photos')
+        .reply(200, photosMocked);
+      test(1)
+        .then(res => {
+          res.should.have.status(200);
+          res.body.should.be.a('array');
+          res.body.should.have.lengthOf(3);
           dictum.chai(res);
         })
         .then(() => done());

--- a/test/albums.js
+++ b/test/albums.js
@@ -222,9 +222,7 @@ describe('users', () => {
       chai
         .request(server)
         .get(`/users/albums/1/photos`)
-        .catch(error =>
-          handleError(error, 'You must be logged to see the photos', errors.AUTHENTICATION_ERROR)
-        )
+        .catch(error => handleError(error, errorMessage.logRequired, errors.AUTHENTICATION_ERROR))
         .then(() => done());
     });
     it('should success and return a message telling that the user does not purchased the album', done => {
@@ -238,8 +236,8 @@ describe('users', () => {
     });
     it('should success when listing photos of a purchased album', done => {
       nock('https://jsonplaceholder.typicode.com')
-        .get('/photos')
-        .reply(200, photosMocked);
+        .get(`/photos?albumId=1`)
+        .reply(200, photosMocked.slice(0, 3));
       test(1)
         .then(res => {
           res.should.have.status(200);


### PR DESCRIPTION
## Summary

Pull request for _list photos_ card. Now the server can resolve HTTP Get request from `/users/albums/:id/photos`, where `id` is the id of the album that the photos will be seen. To consume this service, the user must be logged. First, the server will find if the requested album is already purchased by the user. Then, it will fetch https://jsonplaceholder.typicode.com/photos, and filter the returned array by the id of the requested album; and finally, return the photos.

## Test cases
The photos endpoint was mocked.

1. **When the user is not logged:** If the user is not logged, then return a bad response (code 400) with the message _You must be logged to see the albums_ and internal code _authentication\_error_.

2. **When the user has not purchased the album:** If the user has not purchased the album, then return a bad response (code 400) with the message _The user has not purchased this album_ and internal code _list\_photos\_error_.

3. **When the user has purchased the album:** If the user has purchased the album, then return the photos from that album.

## Screenshots
When the user is not logged
![image](https://user-images.githubusercontent.com/19678474/49472809-62f7af80-f7de-11e8-8c7c-a9bb6b129a09.png)
When the album is not purchased by the user
![image](https://user-images.githubusercontent.com/19678474/49472831-7145cb80-f7de-11e8-99ce-eaef2bf8eba7.png)
When is purchased
![image](https://user-images.githubusercontent.com/19678474/49472854-7c98f700-f7de-11e8-89a3-0c4be2966a61.png)

## Trello Card

https://trello.com/c/95kX8KMC