### PR TITLE
Disable tokens

### DIFF
--- a/app/controllers/users.js
+++ b/app/controllers/users.js
@@ -29,7 +29,7 @@ exports.authenticate = (request, response, next) => {
       if (user) {
         bcrypt.compare(password, user.password).then(isValid => {
           if (isValid) {
-            const authentication = sessionManager.encode({ email, password });
+            const authentication = sessionManager.encode({ email, date: Date.now() });
             response
               .status(200)
               .set(sessionManager.HEADER_NAME, authentication)
@@ -80,4 +80,13 @@ exports.createAdmin = (request, response) => {
       exports.create(request, response);
     }
   });
+};
+
+exports.logOut = ({ userLogged: { email } }, response) => {
+  User.invalidateToken(email)
+    .then(() => response.status(200).send(`Sessions invalidated for ${email}`))
+    .catch(error => {
+      logger.error(error);
+      response.status(400).send(errors.createUserError('Unexpected data base error'));
+    });
 };

--- a/app/controllers/users.js
+++ b/app/controllers/users.js
@@ -1,9 +1,12 @@
 const logger = require('../logger'),
   bcrypt = require('bcryptjs'),
   sessionManager = require('../services/sessionManager'),
+  config = require('../../config'),
   User = require('../models').users,
   userMw = require('../middlewares/users'),
   errors = require('../errors');
+
+const EXPIRY_TIME = config.common.session.expiryTime || 1;
 
 exports.create = ({ user }, response, next) => {
   User.createModel(user)
@@ -30,7 +33,7 @@ exports.authenticate = (request, response, next) => {
             response
               .status(200)
               .set(sessionManager.HEADER_NAME, authentication)
-              .send(user);
+              .send({ user, session: `Your session will expire in ${EXPIRY_TIME} seconds` });
             logger.info(`The user with email ${user.email} is now logged`);
           } else {
             response.status(400).send(errors.authenticationError(['The password is not correct']));

--- a/app/controllers/users.js
+++ b/app/controllers/users.js
@@ -82,9 +82,9 @@ exports.createAdmin = (request, response) => {
   });
 };
 
-exports.logOut = ({ userLogged: { email } }, response) => {
-  User.invalidateToken(email)
-    .then(() => response.status(200).send(`Sessions invalidated for ${email}`))
+exports.logOut = ({ userLogged }, response) => {
+  User.invalidateToken(userLogged)
+    .then(() => response.status(200).send(`Sessions invalidated for ${userLogged.email}`))
     .catch(error => {
       logger.error(error);
       response.status(400).send(errors.createUserError('Unexpected data base error'));

--- a/app/middlewares/auth.js
+++ b/app/middlewares/auth.js
@@ -18,8 +18,10 @@ exports.authenticated = (request, response, next) => {
   const token = request.headers[sessionManager.HEADER_NAME];
   if (token) {
     try {
-      const { email } = sessionManager.decode(token);
+      const { email, date } = sessionManager.decode(token);
       User.findByEmail(email).then(user => {
+        if (date < user.invalidTokenDate)
+          return response.status(400).send(errors.authenticationError(['Your session has been invalided']));
         if (user) request.userLogged = user;
         next();
       });

--- a/app/middlewares/auth.js
+++ b/app/middlewares/auth.js
@@ -24,7 +24,10 @@ exports.authenticated = (request, response, next) => {
         next();
       });
     } catch (error) {
-      return response.status(400).send(errors.authenticationError(['The token is not valid']));
+      response.status(400);
+      if (error.name === 'TokenExpiredError')
+        return response.send(errors.authenticationError(['Your session has expired']));
+      return response.send(errors.authenticationError(['The token is not valid']));
     }
   } else {
     next();

--- a/app/middlewares/auth.js
+++ b/app/middlewares/auth.js
@@ -21,7 +21,7 @@ exports.authenticated = (request, response, next) => {
       const { email, date } = sessionManager.decode(token);
       User.findByEmail(email).then(user => {
         if (date < user.invalidTokenDate)
-          return response.status(400).send(errors.authenticationError(['Your session has been invalided']));
+          return response.status(400).send(errors.authenticationError(['Your session has been invalidated']));
         if (user) request.userLogged = user;
         next();
       });

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -34,6 +34,12 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.BOOLEAN,
         allowNull: false,
         default: false
+      },
+      invalidTokenDate: {
+        field: 'invalid_token_date',
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: sequelize.fn('NOW')
       }
     },
     {
@@ -68,6 +74,9 @@ module.exports = (sequelize, DataTypes) => {
         email: user.email
       }
     });
+
+  User.invalidateToken = email =>
+    User.findByEmail(email).then(user => user.update({ invalidTokenDate: Date.now() }));
 
   return User;
 };

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -75,8 +75,7 @@ module.exports = (sequelize, DataTypes) => {
       }
     });
 
-  User.invalidateToken = email =>
-    User.findByEmail(email).then(user => user.update({ invalidTokenDate: Date.now() }));
+  User.invalidateToken = user => user.update({ invalidTokenDate: Date.now() });
 
   return User;
 };

--- a/app/routes.js
+++ b/app/routes.js
@@ -18,4 +18,5 @@ exports.init = app => {
     albums.boughts
   );
   app.get('/users/albums/:id/photos', [authMw.authenticated, authMw.logRequired], albums.photo);
+  app.post('/users/sessions/invalidate_all', [authMw.authenticated, authMw.logRequired], users.logOut);
 };

--- a/app/services/sessionManager.js
+++ b/app/services/sessionManager.js
@@ -9,5 +9,3 @@ exports.HEADER_NAME = config.common.session.header_name;
 exports.encode = payload => jwt.sign(payload, SECRET, { expiresIn: EXPIRY_TIME });
 
 exports.decode = toDecode => jwt.verify(toDecode, SECRET);
-
-exports.sign = payload => jwt.sign(payload, SECRET, { expiresIn: EXPIRY_TIME });

--- a/app/services/sessionManager.js
+++ b/app/services/sessionManager.js
@@ -1,14 +1,13 @@
-const jwt = require('jwt-simple'),
+const jwt = require('jsonwebtoken'),
   config = require('./../../config');
 
 const SECRET = config.common.session.secret;
+const EXPIRY_TIME = Number(config.common.session.expiryTime) || 1;
 
 exports.HEADER_NAME = config.common.session.header_name;
 
-exports.encode = toEncode => {
-  return jwt.encode(toEncode, SECRET);
-};
+exports.encode = payload => jwt.sign(payload, SECRET, { expiresIn: EXPIRY_TIME });
 
-exports.decode = toDecode => {
-  return jwt.decode(toDecode, SECRET);
-};
+exports.decode = toDecode => jwt.verify(toDecode, SECRET);
+
+exports.sign = payload => jwt.sign(payload, SECRET, { expiresIn: EXPIRY_TIME });

--- a/config/index.js
+++ b/config/index.js
@@ -44,7 +44,8 @@ const config = {
     },
     session: {
       header_name: 'authorization',
-      secret: process.env.NODE_API_SESSION_SECRET
+      secret: process.env.NODE_API_SESSION_SECRET,
+      expiryTime: process.env.EXPIRY_TIME
     },
     rollbar: {
       accessToken: process.env.ROLLBAR_ACCESS_TOKEN,

--- a/config/testing.js
+++ b/config/testing.js
@@ -6,7 +6,8 @@ exports.config = {
       name: process.env.NODE_API_DB_NAME_TEST
     },
     session: {
-      secret: 'some-super-secret'
+      secret: 'some-super-secret',
+      expiryTime: 3
     }
   }
 };

--- a/migrations/migrations/20181204083142-create-user.js
+++ b/migrations/migrations/20181204083142-create-user.js
@@ -1,0 +1,13 @@
+module.exports = {
+  up(queryInterface, Sequelize) {
+    return queryInterface.addColumn('users', 'invalid_token_date', {
+      type: Sequelize.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.fn('NOW')
+    });
+  },
+
+  down(queryInterface, Sequelize) {
+    return queryInterface.removeColumn('users', 'invalid_token_date');
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1284,6 +1284,11 @@
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "buffer-writer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz",
@@ -1528,7 +1533,7 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         }
@@ -2067,6 +2072,14 @@
         "jsbn": "0.1.1"
       }
     },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
+      "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "editorconfig": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.3.tgz",
@@ -2147,7 +2160,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
@@ -4407,6 +4420,29 @@
         "graceful-fs": "4.1.11"
       }
     },
+    "jsonwebtoken": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.4.0.tgz",
+      "integrity": "sha512-coyXjRTCy0pw5WYBpMvWOMN+Kjaik2MwTUIq9cna/W7NpO9E+iYbumZONAz3hcr+tXFJECoQVrtmIoC3Oz0gvg==",
+      "requires": {
+        "jws": "3.1.5",
+        "lodash.includes": "4.3.0",
+        "lodash.isboolean": "3.0.3",
+        "lodash.isinteger": "4.0.4",
+        "lodash.isnumber": "3.0.3",
+        "lodash.isplainobject": "4.0.6",
+        "lodash.isstring": "4.0.1",
+        "lodash.once": "4.1.1",
+        "ms": "2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -4417,6 +4453,25 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "jwa": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
+      "integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.10",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "jws": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
+      "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
+      "requires": {
+        "jwa": "1.1.6",
+        "safe-buffer": "5.1.1"
       }
     },
     "jwt-simple": {
@@ -4524,11 +4579,46 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
     "lodash.merge": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
       "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
       "dev": true
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.unescape": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "body-parser": "^1.18.2",
     "cors": "^2.8.4",
     "express": "^4.16.2",
+    "jsonwebtoken": "^8.4.0",
     "jwt-simple": "^0.5.1",
     "morgan": "^1.9.0",
     "nock": "^10.0.2",

--- a/test/albums.js
+++ b/test/albums.js
@@ -248,4 +248,22 @@ describe('users', () => {
         .then(() => done());
     });
   });
+  describe('Expire Token Test', () => {
+    it('should fail because session has expire', done => {
+      chai
+        .request(server)
+        .post('/users/sessions')
+        .send({ email: regular, password: '123456789' })
+        .then(loggedResponse => {
+          setTimeout(() => {
+            chai
+              .request(server)
+              .get('/users/albums/1/photos')
+              .set(sessionManager.HEADER_NAME, loggedResponse.headers[sessionManager.HEADER_NAME])
+              .catch(error => handleError(error, 'Your session has expired', errors.AUTHENTICATION_ERROR))
+              .then(() => done());
+          }, 3200);
+        });
+    });
+  });
 });

--- a/test/albums.js
+++ b/test/albums.js
@@ -265,5 +265,40 @@ describe('users', () => {
           }, 3200);
         });
     });
+
+    it('should fail because the session has been invalidated', done => {
+      nock('https://jsonplaceholder.typicode.com')
+        .get(`/photos?albumId=1`)
+        .reply(200, photosMocked.slice(0, 3));
+      chai
+        .request(server)
+        .post('/users/sessions')
+        .send({ email: regular, password: '123456789' })
+        .then(loggedResponse => {
+          const token = loggedResponse.headers[sessionManager.HEADER_NAME];
+          chai
+            .request(server)
+            .get('/users/albums/1/photos')
+            .set(sessionManager.HEADER_NAME, token)
+            .then(successful => {
+              successful.should.have.status(200);
+              chai
+                .request(server)
+                .post('/users/sessions/invalidate_all')
+                .set(sessionManager.HEADER_NAME, token)
+                .then(loggedOut => {
+                  loggedOut.should.have.status(200);
+                  chai
+                    .request(server)
+                    .get('/users/albums/1/photos')
+                    .set(sessionManager.HEADER_NAME, token)
+                    .catch(error =>
+                      handleError(error, 'Your session has been invalidated', errors.AUTHENTICATION_ERROR)
+                    )
+                    .then(() => done());
+                });
+            });
+        });
+    });
   });
 });

--- a/test/users.js
+++ b/test/users.js
@@ -157,10 +157,8 @@ describe('users', () => {
         .then(res => {
           res.should.have.status(200);
           res.should.be.json;
-          res.body.should.have.property('firstName');
-          res.body.should.have.property('lastName');
-          res.body.should.have.property('email');
-          res.body.should.have.property('password');
+          res.body.should.have.property('user');
+          res.body.should.have.property('session');
           res.headers.should.have.property(sessionManager.HEADER_NAME);
           dictum.chai(res);
         })

--- a/test/users.js
+++ b/test/users.js
@@ -227,13 +227,15 @@ describe('users', () => {
   });
 
   describe('/admin/users POST', () => {
-    const adminLogin = chai
-      .request(server)
-      .post('/users/sessions')
-      .send({ email: 'admin@wolox.co', password: '123456789' });
+    const adminLogin = () => {
+      return chai
+        .request(server)
+        .post('/users/sessions')
+        .send({ email: 'admin@wolox.co', password: '123456789' });
+    };
 
     const sendAndTest = (data, message) =>
-      adminLogin.then(response =>
+      adminLogin().then(response =>
         buildTest('/admin/users', errors.CREATE_USER_ERROR, response.headers[sessionManager.HEADER_NAME])(
           data,
           message
@@ -271,7 +273,7 @@ describe('users', () => {
     });
 
     it('should be successful and create a new user as admin', done => {
-      adminLogin.then(loggedResponse => {
+      adminLogin().then(loggedResponse => {
         chai
           .request(server)
           .post('/admin/users')
@@ -290,7 +292,7 @@ describe('users', () => {
 
     it('should be successful and update user as admin', done => {
       const sendUser = testUser('email', 'unique@wolox.co');
-      adminLogin.then(loggedResponse => {
+      adminLogin().then(loggedResponse => {
         chai
           .request(server)
           .post('/admin/users')


### PR DESCRIPTION
## Summary

Pull request for _invalidate tokens_ card. Now the server can resolve HTTP Post request from `/users/sessions/invalidate_all`. When consuming this services, all previously generated tokens will be disabled, forcing the user to LogIn again.

To accomplish this, a new column was added to the user table, called `invalidTokenDate`. This attribute will be updated always when the user consume the new endpoint, saving the actual date. On the other hand, now the payload to be encoded will hold the actual date when the user Log In.

With these two characteristics, before authenticating the user, the token will be decoded and then extracted his date and then, compared with the saved date in the data base. If the token date is before the saved date, then the token has been disabled. 

## Known Issues
### Avoid call the `beforeBulkUpdate` method
To update the field `invalidTokenDate` I used the `User.update` function. When used this function, the `beforeBulkUpdate` was called. By this, the user password is re-encrypted.
To prevent this, I use the user extracted by the previous `User.findByEmail` method and chained the update method, but this time, specifying the attribute:
> User.invalidateToken = user => user.update({ invalidTokenDate: Date.now() });

### *Test Environment*: Session getting invalid
When the test were run, all tests from `/admin/users POST`, that use this const:
> const adminLogin =
      chai
        .request(server)
        .post('/users/sessions')
        .send({ email: 'admin@wolox.co', password: '123456789' });

They began to fail.  This because, every time the test are run, the `dataCreation.js` file, create new users every time; so, the `invalidTokenDate` is different for every test case. Meanwhile, the token generated by the `adminLogin` is only generated the first time because this method:
>const sendAndTest = (data, message) =>
      adminLogin.then(response =>
        buildTest('/admin/users', errors.CREATE_USER_ERROR, response.headers[sessionManager.HEADER_NAME])(
          data,
          message
        )
      );
 
Thus, the token will always be less than the `invalidTokenDate`, generating that the token will be threaten as _disabled token_.

To solve this, just convert the `adminLogin` const as a function. So, when called the `sendAndTest` method, a new token will be always generated.

## Screenshots
Log the user
![image](https://user-images.githubusercontent.com/19678474/49600265-d3264280-f950-11e8-8922-d468620a6cbb.png)
Check if the user can consume a service
![image](https://user-images.githubusercontent.com/19678474/49600280-d9b4ba00-f950-11e8-9476-11367baf9ba7.png)
Invalidate the sessions
![image](https://user-images.githubusercontent.com/19678474/49600298-e2a58b80-f950-11e8-9f0a-9c111551a389.png)
Sessions disabled
![image](https://user-images.githubusercontent.com/19678474/49600308-e89b6c80-f950-11e8-98ce-07745ec35e89.png)

## Trello Card

https://trello.com/c/Lb02Vw6n
